### PR TITLE
new reading heuristics, more tests, bump version 0.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FamaFrenchData"
 uuid = "bd2a388e-9788-4ef7-9fc3-f4c919ffde82"
 authors = ["Tyler Beason <tbeas12@gmail.com>"]
-version = "0.1.5"
+version = "0.2.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,6 +25,30 @@ using Test
         @test length(tablesff) == 2
 
         @test ncol(tablesff[1]) == 5
+
+        @test tablesff[1].Date[1] == 192607
+
+        @test tablesff[2].Date[1] == 1927
+
+        tablesff, tablenotesff, filenotesff = readFamaFrench("F-F_Momentum_Factor")
+        @test length(tablesff) == 2
+
+        @test ncol(tablesff[1]) == 2
+
+        tablesff, tablenotesff, filenotesff = readFamaFrench("25_Portfolios_5x5")
+        @test length(tablesff) == 10
+
+        @test ncol(tablesff[1]) == 26
+
+        @test tablesff[1].Date[1] == 192607
+
+
+        tablesff, tablenotesff, filenotesff = readFamaFrench("ME_Breakpoints",header=false)
+        @test length(tablesff) == 1
+
+        @test ncol(tablesff[1]) == 22
+
+        @test tablesff[1].Date[1] == 192512
     end
 
     @testset "Download" begin
@@ -37,6 +61,10 @@ using Test
     end
 
     @testset "Unexported" begin
+        @test FamaFrenchData.strip_rn("abc 123\r\n") == "abc 123 "
+
+        @test FamaFrenchData.contiguousblocks([1,2,3,1,1,1,2,2,2,2,1,2,2,2,2,2]) == [7:10, 12:16]
+
         @test FamaFrenchData.lastornothing([1;2]) == 2
 
         @test FamaFrenchData.pathtoFamaFrench("F-F_Research_Data_Factors") == "http://mba.tuck.dartmouth.edu/pages/faculty/ken.french/ftp/F-F_Research_Data_Factors_CSV.zip"


### PR DESCRIPTION
Now uses a much smarter algorithm for finding the tables (fixes #22).

Added tests related to that case as well.

Additionally: No longer normalizes column names because DataFrames introduced string accessors. This is breaking so I'm bumping the version from 0.1.5 to 0.2.0.