### PR TITLE
Add automatic caching functionality with 24-hour expiration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FamaFrenchData"
 uuid = "bd2a388e-9788-4ef7-9fc3-f4c919ffde82"
 authors = ["Tyler Beason <tbeas12@gmail.com>"]
-version = "0.4.4"
+version = "0.5.0"
 
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"

--- a/Project.toml
+++ b/Project.toml
@@ -8,12 +8,14 @@ CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+Scratch = "6c6a2e73-6563-6170-7368-637461726353"
 ZipFile = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
 
 [compat]
 CSV = "0.10, 1"
 DataFrames = "1"
 Downloads = "1"
+Scratch = "1"
 ZipFile = "0.10, 1"
 julia = "1.6"
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,35 @@ To add the package, type `] add FamaFrenchData` at the Julia REPL.
 
 Once added, type `using FamaFrenchData` to import the package.
 
-The package exports 3 functions: `readFamaFrench`, `downloadFamaFrench`, and `listFamaFrench`.
+The package exports 4 functions: `readFamaFrench`, `downloadFamaFrench`, `listFamaFrench`, and `clearFamaFrenchCache`.
 
 For help with any of these functions, use `?` at the REPL (eg. `?readFamaFrench`).
 
 Please consult the online [documentation](https://tbeason.github.io/FamaFrenchData.jl/stable) for additional detail.
+
+### Automatic Caching
+
+The package now includes automatic caching functionality to improve performance and reduce network requests. Downloaded data is cached locally and automatically expires after 24 hours (since the data is updated at most daily). This means:
+
+- **First call**: Downloads data from the web and caches it locally
+- **Subsequent calls**: Uses cached data if it's less than 24 hours old
+- **After 24 hours**: Automatically downloads fresh data and updates the cache
+
+You can customize this behavior:
+
+```julia
+# Use cache with default 24-hour expiration
+tables, tablenotes, filenotes = readFamaFrench("F-F_Research_Data_Factors")
+
+# Bypass cache for a specific call
+tables, tablenotes, filenotes = readFamaFrench("F-F_Research_Data_Factors", use_cache=false)
+
+# Use cache with custom expiration (12 hours)
+tables, tablenotes, filenotes = readFamaFrench("F-F_Research_Data_Factors", cache_max_age=12)
+
+# Clear all cached data
+clearFamaFrenchCache()
+```
 
 ## Example 
 The Fama-French 3 factor model is a commonly used empirical asset pricing model. This example retrieves the full time series of FF3 monthly and annual returns.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,7 @@ To add the package, type `] add FamaFrenchData` at the Julia REPL.
 
 Once added, type `using FamaFrenchData` to import the package.
 
-The package exports 3 functions: `readFamaFrench`, `downloadFamaFrench`, and `listFamaFrench`.
+The package exports 4 functions: `readFamaFrench`, `downloadFamaFrench`, `listFamaFrench`, and `clearFamaFrenchCache`.
 
 For help with any of these functions, use `?` at the REPL (eg. `?readFamaFrench`).
 
@@ -41,6 +41,34 @@ using FamaFrenchData
 FFnames = listFamaFrench()
 ```
 
+## Caching
+
+The package includes automatic caching functionality using [Scratch.jl](https://github.com/JuliaPackaging/Scratch.jl) to improve performance and reduce network requests. Downloaded data is cached locally and automatically expires after 24 hours (since the data is updated at most daily).
+
+### How Caching Works
+
+- **First call**: Downloads data from the web and caches it in a persistent scratch space
+- **Subsequent calls**: Uses cached data if it's less than 24 hours old
+- **After 24 hours**: Automatically downloads fresh data and updates the cache
+
+### Customizing Cache Behavior
+
+```julia
+# Use cache with default 24-hour expiration
+tables, tablenotes, filenotes = readFamaFrench("F-F_Research_Data_Factors")
+
+# Bypass cache for a specific call (always download fresh)
+tables, tablenotes, filenotes = readFamaFrench("F-F_Research_Data_Factors", use_cache=false)
+
+# Use cache with custom expiration (e.g., 12 hours)
+tables, tablenotes, filenotes = readFamaFrench("F-F_Research_Data_Factors", cache_max_age=12)
+
+# Clear all cached data
+clearFamaFrenchCache()
+```
+
+The cache is stored in a scratch space managed by Julia, which means it persists across Julia sessions and is automatically cleaned up when the package is removed.
+
 ## Additional Notes
 
  - Original files use `-99.99` or `-999` to encode missing values, I attempt to replace these with `missing`.
@@ -62,4 +90,5 @@ I am not affiliated with the Ken French Data Library. This package does not "shi
 readFamaFrench
 downloadFamaFrench
 listFamaFrench
+clearFamaFrenchCache
 ```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,4 +69,57 @@ using Test
 
         @test FamaFrenchData.pathtoFamaFrench("F-F_Research_Data_Factors") == "http://mba.tuck.dartmouth.edu/pages/faculty/ken.french/ftp/F-F_Research_Data_Factors_CSV.zip"
     end
+
+    @testset "Caching" begin
+        # Clear cache before starting tests
+        clearFamaFrenchCache()
+
+        # Test that cache directory is created
+        cache_dir = FamaFrenchData.get_cache_dir()
+        @test isdir(cache_dir)
+
+        # Test basic caching - first call should download
+        test_dataset = "F-F_Momentum_Factor"
+        tables1, notes1, filenotes1 = readFamaFrench(test_dataset)
+
+        # Verify cached file was created
+        cached_path = FamaFrenchData.get_cached_file_path(test_dataset)
+        @test isfile(cached_path)
+        @test FamaFrenchData.is_cache_valid(cached_path, 24)
+
+        # Second call should use cache (verify by checking results are identical)
+        tables2, notes2, filenotes2 = readFamaFrench(test_dataset)
+        @test tables1[1] == tables2[1]
+        @test notes1 == notes2
+
+        # Test cache bypass with use_cache=false
+        tables3, notes3, filenotes3 = readFamaFrench(test_dataset, use_cache=false)
+        @test tables1[1] == tables3[1]  # Data should still be the same
+
+        # Test custom cache_max_age (set to 0 to force re-download)
+        # Wait a tiny bit to ensure file timestamp changes
+        sleep(0.1)
+        tables4, notes4, filenotes4 = readFamaFrench(test_dataset, cache_max_age=0)
+        @test tables1[1] == tables4[1]  # Data should still be the same
+
+        # Verify cache file was updated (modification time should be recent)
+        @test FamaFrenchData.is_cache_valid(cached_path, 1)
+
+        # Test clearFamaFrenchCache
+        count_deleted = clearFamaFrenchCache()
+        @test count_deleted >= 1
+        @test !isfile(cached_path)
+
+        # Test that is_cache_valid returns false for non-existent file
+        @test !FamaFrenchData.is_cache_valid(cached_path, 24)
+
+        # Test with a new dataset to ensure cache works for multiple datasets
+        test_dataset2 = "F-F_Research_Data_Factors"
+        tables5, notes5, filenotes5 = readFamaFrench(test_dataset2)
+        cached_path2 = FamaFrenchData.get_cached_file_path(test_dataset2)
+        @test isfile(cached_path2)
+
+        # Clean up
+        clearFamaFrenchCache()
+    end
 end


### PR DESCRIPTION
Implemented comprehensive caching support using Scratch.jl to improve performance and reduce network requests. Key features:

- Automatic caching of downloaded data with 24-hour default expiration
- Configurable cache lifetime via cache_max_age parameter
- Option to bypass cache with use_cache=false parameter
- New clearFamaFrenchCache() function to manage cached data
- Persistent cache across Julia sessions using Scratch.jl

Changes:
- Added Scratch.jl dependency to Project.toml
- Enhanced readFamaFrench() with caching support
- Added cache management helper functions (get_cache_dir, get_cached_file_path, is_cache_valid)
- Added clearFamaFrenchCache() exported function
- Comprehensive test suite for caching functionality
- Updated README and documentation with caching examples

The cache automatically expires after 24 hours since Fama-French data is updated at most daily. This provides a good balance between performance and data freshness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)